### PR TITLE
Add Doxygen pages auto-generation

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,0 +1,65 @@
+name: Deploy Doxygen to Pages
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["master"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  BUILD_PATH: "sdk" 
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install pandoc and doxygen
+        run: |
+          sudo apt install pandoc doxygen
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Build Doxygen
+        run: |
+              cd sdk 
+              mkdir -p doc
+              doxygen Doxyfile
+      
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: sdk/doc
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Install pandoc and doxygen
         run: |
-          sudo apt install pandoc doxygen
+          sudo apt install pandoc doxygen graphviz sphinx-doc
       - name: Setup python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
This should add the Doxygen support and build the documentation directly to github pages. Tested on my fork